### PR TITLE
Measure with UserTiming and emit CSV when finished

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
   <h1>Web Worker perf test</h1>
   <p>Look in the console</p>
   <pre id="display"></pre>
+  <script src="https://rawgit.com/nicjansma/usertiming.js/master/dist/usertiming.min.js"></script>
   <script>
 
     var MAX_MESSAGE_SIZE = 30;

--- a/index.html
+++ b/index.html
@@ -81,7 +81,16 @@
           }
         } else {
           if (log) {
-            console.timeEnd('size: ' + iterations);
+            performance.measure(
+              stringification + '-size-' + iterations,
+              stringification + '-size-' + iterations + '-start');
+            console.log(
+              'size:',
+              iterations,
+              performance.getEntriesByName(
+                stringification + '-size-' + iterations
+              ).pop().duration
+            );
           }
           worker.removeEventListener('message', listener);
           cb();
@@ -90,7 +99,7 @@
 
       worker.addEventListener('message', listener);
       if (log) {
-        console.time('size: ' + iterations);
+        performance.mark(stringification + '-size-' + iterations + '-start');
       }
       next();
     }
@@ -121,6 +130,21 @@
 
     promise = promise.then(function () {
       document.getElementById('display').innerHTML = 'Done.';
+      console.log(
+        Object.keys(workers).map(function (key) {
+          var results = performance.getEntriesByType('measure')
+            .filter(function (measure) {
+              return measure.name.indexOf(key) > -1;
+            })
+            .map(function (measure) {
+              return measure.duration;
+            });
+          results.unshift(key);
+          console.log(results);
+          return results.join(',');
+        })
+        .join('\n')
+      );
     });
 
   </script>


### PR DESCRIPTION
Previously, this benchmark emitted its results per iteration to the console with
`console.time` and `console.timeEnd`. This is a bummer if you want to do any
kind of analysis on the data.

Instead, use `performance.mark` and `measure` to capture the timing data, and
then emit the results to the console in CSV format when finished.
