### PR TITLE
Add tests of msgpack and reusing buffer

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,17 +4,46 @@
   <p>Look in the console</p>
   <pre id="display"></pre>
   <script src="https://rawgit.com/nicjansma/usertiming.js/master/dist/usertiming.min.js"></script>
+  <script src="https://rawgit.com/kawanet/msgpack-lite/master/dist/msgpack.min.js"></script>
   <script>
 
     var MAX_MESSAGE_SIZE = 30;
     var ITERATIONS = 50000;
 
     var workers = {
-      //arraybuffer: new Worker('arraybuffer.js'),
+      arraybuffer: new Worker('arraybuffer.js'),
+      'single-arraybuffer': new Worker('single-arraybuffer.js'),
+      msgpack: new Worker('msgpack.js'),
       full: new Worker('full.js'),
       partial: new Worker('partial.js'),
       none: new Worker('none.js')
     };
+
+    var cStyleBuffer = new ArrayBuffer(MAX_MESSAGE_SIZE * 1000);
+
+    function cStyleBufferToBinaryString(buffer) {
+      var binary = "";
+      var bytes = new Uint8Array(buffer);
+      var length = bytes.byteLength;
+
+      var i = 0;
+      while (bytes[i] > 0) {
+        binary += String.fromCharCode(bytes[i]);
+        i++;
+      }
+      return binary;
+    }
+
+    function binaryStringToCStyleBuffer(bin, buf) {
+      var length = bin.length;
+      var arr = new Uint8Array(buf);
+      for (var i = 0; i < length; i++) {
+        arr[i] = bin.charCodeAt(i);
+      }
+      arr[i] = 0;
+
+      return buf;
+    }
 
     function arrayBufferToBinaryString(buffer) {
       var binary = "";
@@ -58,6 +87,11 @@
           message = JSON.parse(e.data.msg);
         } else if (stringification === 'arraybuffer') {
           message = JSON.parse(arrayBufferToBinaryString(e.data));
+        } else if (stringification === 'single-arraybuffer') {
+          message = JSON.parse(cStyleBufferToBinaryString(e.data));
+          cStyleBuffer = e.data;
+        } else if (stringification === 'msgpack') {
+          message = msgpack.decode(new Uint8Array(e.data));
         } else {
           message = e.data;
         }
@@ -75,6 +109,13 @@
             worker.postMessage(message);
           } else if (stringification === 'arraybuffer') {
             message = binaryStringToArrayBuffer(JSON.stringify(obj));
+            worker.postMessage(message, [message]);
+          } else if (stringification === 'single-arraybuffer') {
+            message =
+              binaryStringToCStyleBuffer(JSON.stringify(obj), cStyleBuffer);
+            worker.postMessage(message, [message]);
+          } else if (stringification === 'msgpack') {
+            message = msgpack.encode(obj).buffer;
             worker.postMessage(message, [message]);
           } else {
             message = obj;
@@ -135,7 +176,7 @@
         Object.keys(workers).map(function (key) {
           var results = performance.getEntriesByType('measure')
             .filter(function (measure) {
-              return measure.name.indexOf(key) > -1;
+              return measure.name.indexOf(key) === 0;
             })
             .map(function (measure) {
               return measure.duration;

--- a/msgpack.js
+++ b/msgpack.js
@@ -1,0 +1,8 @@
+importScripts('https://rawgit.com/kawanet/msgpack-lite/master/dist/msgpack.min.js');
+
+self.addEventListener('message', function (e) {
+  var message = msgpack.decode(new Uint8Array(e.data));
+
+  var buf = msgpack.encode(message).buffer;
+  self.postMessage(buf, [buf]);
+});

--- a/single-arraybuffer.js
+++ b/single-arraybuffer.js
@@ -1,0 +1,30 @@
+function cStyleBufferToBinaryString(buffer) {
+  var binary = "";
+  var bytes = new Uint8Array(buffer);
+  var length = bytes.byteLength;
+
+  var i = 0;
+  while (bytes[i] > 0) {
+    binary += String.fromCharCode(bytes[i]);
+    i++;
+  }
+  return binary;
+}
+
+function binaryStringToCStyleBuffer(bin, buf) {
+  var length = bin.length;
+  var arr = new Uint8Array(buf);
+  for (var i = 0; i < length; i++) {
+    arr[i] = bin.charCodeAt(i);
+  }
+  arr[i] = 0;
+
+  return buf;
+}
+
+self.addEventListener('message', function (e) {
+  var buf = e.data;
+  var message = JSON.parse(cStyleBufferToBinaryString(buf));
+  buf = binaryStringToCStyleBuffer(JSON.stringify(message), buf);
+  self.postMessage(buf, [buf]);
+});


### PR DESCRIPTION
The ArrayBuffer test creates a new buffer for each message, incurring allocation
overhead per message. Instead, reuse a single buffer, transfering it repeatedly
from parent page to worker and back again.

Add a test that uses msgpack-lite to measure how fast it is to serialize
messages to an ArrayBuffer using MessagePack.
